### PR TITLE
One implementation for both EventEmitter and EventBus

### DIFF
--- a/src/common-types.ts
+++ b/src/common-types.ts
@@ -1,0 +1,3 @@
+export type EventResult = Promise<void> | void;
+
+export type AnyListener = (...args: any[]) => EventResult;

--- a/src/event-bus.test.ts
+++ b/src/event-bus.test.ts
@@ -1,9 +1,9 @@
-import { EventBus, EventType } from "./event-bus";
+import { EventBus, EventType, IEventBus } from "./event-bus";
 import { createPromise, testPromiseResolved, testPromiseResolving } from "./test/util";
 
 const TestEvent = "test" as EventType<(a: string, b: string) => Promise<void> | void>;
 
-let emitter: EventBus;
+let emitter: IEventBus;
 let listener: jest.Mock<Promise<void> | void, [string, string]>;
 
 beforeAll(() => {

--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -1,4 +1,4 @@
-type AnyListener = (...args: any[]) => void | Promise<void>;
+import { AnyListener } from "./common-types";
 
 export type EventType<T extends AnyListener> = string & { __tag: T };
 

--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -1,4 +1,5 @@
 import { AnyListener } from "./common-types";
+import { EventEmitterImpl } from "./implementation";
 
 export type EventType<T extends AnyListener> = string & { __tag: T };
 
@@ -45,52 +46,4 @@ export interface IEventBus {
     emitAsync<T extends AnyListener>(event: EventType<T>, ...args: Parameters<T>): Promise<void>;
 }
 
-export class EventBus implements IEventBus {
-    private readonly listeners: { [event: string]: AnyListener[] } = {};
-
-    on<T extends AnyListener>(event: EventType<T>, listener: T) {
-        const listeners = this.listeners[event] as T[] | undefined;
-        (listeners || (this.listeners[event] = [])).push(listener);
-    }
-
-    once<T extends AnyListener>(event: EventType<T>, listener: T) {
-        const onceListener = ((...args: Parameters<T>) => {
-            this.off(event, onceListener);
-            listener(...args);
-        }) as T;
-
-        this.on(event, onceListener);
-    }
-
-    off<T extends AnyListener>(event: EventType<T>, listener: T) {
-        const listeners = this.listeners[event];
-        if (listeners) {
-            const i = listeners.indexOf(listener);
-
-            if (i !== -1) {
-                listeners.splice(i, 1);
-            }
-        }
-    }
-
-    getListeners<T extends AnyListener>(event: EventType<T>): T[] {
-        const listeners = this.listeners[event] as T[] | undefined;
-        return listeners || [];
-    }
-
-    emit<T extends AnyListener>(event: EventType<T>, ...args: Parameters<T>) {
-        const listeners = this.listeners[event] as T[] | undefined;
-        if (listeners) {
-            listeners.forEach((listener) => listener(...args));
-        }
-    }
-
-    emitAsync<T extends AnyListener>(event: EventType<T>, ...args: Parameters<T>): Promise<void> {
-        const listeners = this.listeners[event] as T[] | undefined;
-        if (listeners && listeners.length !== 0) {
-            return Promise.all(listeners.map((listener) => listener(...args))) as any;
-        }
-
-        return Promise.resolve();
-    }
-}
+export const EventBus = EventEmitterImpl as new () => IEventBus;

--- a/src/event-emitter.test.ts
+++ b/src/event-emitter.test.ts
@@ -1,5 +1,5 @@
-import { EventEmitter } from "./event-emitter";
-import { createPromise, testPromiseResolving, testPromiseResolved } from "./test/util";
+import { EventEmitter, IEventEmitter } from "./event-emitter";
+import { createPromise, testPromiseResolved, testPromiseResolving } from "./test/util";
 
 // It is necessary to use a type literal here, because we would otherwise get a compiler error
 // tslint:disable-next-line: interface-over-type-literal
@@ -7,7 +7,7 @@ type TestEvents = {
     "test": (a: string, b: string) => Promise<void> | void;
 };
 
-let emitter: EventEmitter<TestEvents>;
+let emitter: IEventEmitter<TestEvents>;
 let listener: jest.Mock<Promise<void> | void, [string, string]>;
 
 beforeAll(() => {

--- a/src/event-emitter.ts
+++ b/src/event-emitter.ts
@@ -1,4 +1,4 @@
-type AnyListener = (...args: any[]) => void | Promise<void>;
+import { AnyListener } from "./common-types";
 
 export interface IEventEmitter<TEvents extends {[event: string]: AnyListener}> {
     /**

--- a/src/implementation.ts
+++ b/src/implementation.ts
@@ -1,0 +1,51 @@
+import { AnyListener } from "./common-types";
+
+export class EventEmitterImpl {
+    private readonly listeners: { [event: string]: undefined | AnyListener[] } = {};
+
+    on(event: string, listener: AnyListener) {
+        const listeners: AnyListener[] | undefined = this.listeners[event];
+        (listeners || (this.listeners[event] = [])).push(listener);
+    }
+
+    once(event: string, listener: AnyListener) {
+        const onceListener = ((...args: any[]) => {
+            this.off(event, onceListener);
+            return listener(...args);
+        });
+
+        this.on(event, onceListener);
+    }
+
+    off(event: string, listener: AnyListener) {
+        const listeners = this.listeners[event];
+        if (listeners) {
+            const i = listeners.indexOf(listener);
+
+            if (i !== -1) {
+                listeners.splice(i, 1);
+            }
+        }
+    }
+
+    getListeners(event: string): AnyListener[] {
+        const listeners: AnyListener[] | undefined = this.listeners[event];
+        return listeners || [];
+    }
+
+    emit(event: string, ...args: any[]) {
+        const listeners: AnyListener[] | undefined = this.listeners[event];
+        if (listeners) {
+            listeners.forEach((listener) => listener(...args));
+        }
+    }
+
+    emitAsync(event: string, ...args: any[]): Promise<void> {
+        const listeners: AnyListener[] | undefined = this.listeners[event];
+        if (listeners && listeners.length !== 0) {
+            return Promise.all(listeners.map((listener) => listener(...args))) as any;
+        }
+
+        return Promise.resolve();
+    }
+}


### PR DESCRIPTION
Since `EventEmitter` and `EventBus` are implemented in the same way, they should share a single implementation. This pull request removes both classes and moves them to `EventEmitterImpl`, which gets then casted in to constructors for `IEventEmitter` and `EventBus`.