### PR TITLE
Copy the listener array before executing listeners

### DIFF
--- a/src/implementation.test.ts
+++ b/src/implementation.test.ts
@@ -76,3 +76,29 @@ test("listening once", () => {
     emitter.emit("test-event", "a", "b");
     expect(listener).not.toBeCalled();
 });
+
+test("removing listeners during execution should have no immediate effect", () => {
+    emitter.on("test-event", () => {
+        emitter.off("test-event", listener);
+    });
+
+    emitter.on("test-event", listener);
+
+    emitter.emit("test-event", "a", "b");
+    expect(listener).toBeCalled();
+
+    listener.mockReset();
+    emitter.emit("test-event", "a", "b");
+    expect(listener).not.toBeCalled();
+});
+
+test("removing listeners during async execution should have no immediate effect", async () => {
+    emitter.on("test-event", listener);
+
+    await emitter.emitAsync("test-event", "a", "b");
+    expect(listener).toBeCalled();
+
+    listener.mockReset();
+    await emitter.emitAsync("test-event", "a", "b");
+    expect(listener).not.toBeCalled();
+});

--- a/src/implementation.ts
+++ b/src/implementation.ts
@@ -30,19 +30,19 @@ export class EventEmitterImpl {
 
     getListeners(event: string): AnyListener[] {
         const listeners: AnyListener[] | undefined = this.listeners[event];
-        return listeners || [];
+        return listeners ? [...listeners] : [];
     }
 
     emit(event: string, ...args: any[]) {
-        const listeners: AnyListener[] | undefined = this.listeners[event];
-        if (listeners) {
+        const listeners: AnyListener[] | undefined = this.getListeners(event);
+        if (listeners.length !== 0) {
             listeners.forEach((listener) => listener(...args));
         }
     }
 
     emitAsync(event: string, ...args: any[]): Promise<void> {
-        const listeners: AnyListener[] | undefined = this.listeners[event];
-        if (listeners && listeners.length !== 0) {
+        const listeners: AnyListener[] | undefined = this.getListeners(event);
+        if (listeners.length !== 0) {
             return Promise.all(listeners.map((listener) => listener(...args))) as any;
         }
 


### PR DESCRIPTION
As @amariq mentioned in #2, removing listeners while emitting an event leads to unexpected behaviour where the removed listeners might or might not be called, depending on the order in which they've been added. The solution is to copy the array of listeners before calling them so that modifications don't affect the current execution.