### PR TITLE
Return a function to remove a listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,3 +117,28 @@ emitter.on("some-event", async () => {
 // wait for all listeners to complete
 await emitter.emitAsync("some-event");
 ```
+
+### Removing listeners
+Listeners can be removed by either using `off` or or the function returned by `on` and `once`:
+
+Using `off`:
+```typescript
+const listener () => {
+    // something
+};
+
+emitter.on("some-event", listener);
+
+// remove the listener:
+emitter.off("some-event", listener);
+```
+
+Using the returned function:
+```typescript
+const removeListener = emitter.on("some-event", () => {
+    // something
+});
+
+// remove the listener:
+removeListener();
+```

--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -8,15 +8,17 @@ export interface IEventBus {
      * Adds an event listener
      * @param event the event to listen to
      * @param listener the listener to add
+     * @returns a callback that removes the listener
      */
-    on<T extends AnyListener>(event: EventType<T>, listener: T): void;
+    on<T extends AnyListener>(event: EventType<T>, listener: T): () => void;
 
     /**
      * Adds an event listener that will only be called once
      * @param event the event to listen to
      * @param listener the listener to add
+     * @returns a callback that removes the listener
      */
-    once<T extends AnyListener>(event: EventType<T>, listener: T): void;
+    once<T extends AnyListener>(event: EventType<T>, listener: T): () => void;
 
     /**
      * Removes an event listener

--- a/src/event-emitter.ts
+++ b/src/event-emitter.ts
@@ -6,15 +6,17 @@ export interface IEventEmitter<TEvents extends {[event: string]: AnyListener}> {
      * Adds an event listener
      * @param event the event to listen to
      * @param listener the listener to add
+     * @returns a callback that removes the listener
      */
-    on<E extends keyof TEvents>(event: E, listener: TEvents[E]): void;
+    on<E extends keyof TEvents>(event: E, listener: TEvents[E]): () => void;
 
     /**
      * Adds an event listener that will only be called once
      * @param event the event to listen to
      * @param listener the listener to add
+     * @returns a callback that removes the listener
      */
-    once<E extends keyof TEvents>(event: E, listener: TEvents[E]): void;
+    once<E extends keyof TEvents>(event: E, listener: TEvents[E]): () => void;
 
     /**
      * Removes an event listener

--- a/src/implementation.test.ts
+++ b/src/implementation.test.ts
@@ -77,6 +77,22 @@ test("listening once", () => {
     expect(listener).not.toBeCalled();
 });
 
+test("removing listeners using the returned callback", () => {
+    const remove = emitter.on("test-event", listener);
+    expect(emitter.getListeners("test-event")).toEqual([listener]);
+
+    remove();
+    expect(emitter.getListeners("test-event")).toEqual([]);
+});
+
+test("removing listeners added with once(...) using the returned callback", () => {
+    const remove = emitter.once("test-event", listener);
+    expect(emitter.getListeners("test-event").length).toBe(1);
+
+    remove();
+    expect(emitter.getListeners("test-event")).toEqual([]);
+});
+
 test("removing listeners during execution should have no immediate effect", () => {
     emitter.on("test-event", () => {
         emitter.off("test-event", listener);

--- a/src/implementation.ts
+++ b/src/implementation.ts
@@ -3,18 +3,20 @@ import { AnyListener } from "./common-types";
 export class EventEmitterImpl {
     private readonly listeners: { [event: string]: undefined | AnyListener[] } = {};
 
-    on(event: string, listener: AnyListener) {
+    on(event: string, listener: AnyListener): () => void {
         const listeners: AnyListener[] | undefined = this.listeners[event];
         (listeners || (this.listeners[event] = [])).push(listener);
+
+        return () => this.off(event, listener);
     }
 
-    once(event: string, listener: AnyListener) {
+    once(event: string, listener: AnyListener): () => void {
         const onceListener = ((...args: any[]) => {
             this.off(event, onceListener);
             return listener(...args);
         });
 
-        this.on(event, onceListener);
+        return this.on(event, onceListener);
     }
 
     off(event: string, listener: AnyListener) {


### PR DESCRIPTION
When a listener is added, `on` and `once` should return a function that removes it. This also enables the removal of listeners added using `once`.